### PR TITLE
Patches

### DIFF
--- a/Client/Camera/Camera.cs
+++ b/Client/Camera/Camera.cs
@@ -56,7 +56,7 @@ namespace Onvif.Core.Client
             try
             {
                 //var device = await OnvifClientFactory.CreateDeviceClientAsync(account.Host, account.UserName, account.Password);
-                var response = await Media.GetProfilesAsync();
+                var response = await Media.GetProfilesAsync().ConfigureAwait(false);
                 return true;
             }
             catch (Exception ex)

--- a/Client/Camera/CameraExtensions.cs
+++ b/Client/Camera/CameraExtensions.cs
@@ -17,7 +17,7 @@ namespace Onvif.Core.Client
 
                 if (focus)// && camera.FocusMode != focusMode
                 {
-                    var image_settings = await imaging.GetImagingSettingsAsync(vsource_token);
+                    var image_settings = await imaging.GetImagingSettingsAsync(vsource_token).ConfigureAwait(false);
                     if (image_settings.Focus == null)
                     {
                         image_settings.Focus = new FocusConfiguration20
@@ -25,17 +25,17 @@ namespace Onvif.Core.Client
                             AutoFocusMode = focusMode
                         };
 
-                        await imaging.SetImagingSettingsAsync(vsource_token, image_settings, false);
+                        await imaging.SetImagingSettingsAsync(vsource_token, image_settings, false).ConfigureAwait(false);
                     }
                     else if (image_settings.Focus.AutoFocusMode != focusMode)
                     {
                         image_settings.Focus.AutoFocusMode = focusMode;
-                        await imaging.SetImagingSettingsAsync(vsource_token, image_settings, false);
+                        await imaging.SetImagingSettingsAsync(vsource_token, image_settings, false).ConfigureAwait(false);
                     }
                     camera.FocusMode = focusMode;
                 }
 
-                await imaging.MoveAsync(vsource_token, focusMove);
+                await imaging.MoveAsync(vsource_token, focusMove).ConfigureAwait(false);
                 return true;
             }
             return false;
@@ -50,13 +50,13 @@ namespace Onvif.Core.Client
                 switch (moveType)
                 {
                     case MoveType.Absolute:
-                        await ptz.AbsoluteMoveAsync(profile_token, vector, speed);
+                        await ptz.AbsoluteMoveAsync(profile_token, vector, speed).ConfigureAwait(false);
                         return true;
                     case MoveType.Relative:
-                        await ptz.RelativeMoveAsync(profile_token, vector, speed);
+                        await ptz.RelativeMoveAsync(profile_token, vector, speed).ConfigureAwait(false);
                         return true;
                     case MoveType.Continuous:
-                        await ptz.ContinuousMoveAsync(profile_token, speed, timeout.ToString());
+                        await ptz.ContinuousMoveAsync(profile_token, speed, timeout.ToString()).ConfigureAwait(false);
                         return true;
                     default:
                         break;

--- a/Client/OnvifClientFactory.cs
+++ b/Client/OnvifClientFactory.cs
@@ -35,7 +35,7 @@ namespace Onvif.Core.Client
 
         public static async Task<DeviceClient> CreateDeviceClientAsync(string host, string username, string password)
         {
-            return await CreateDeviceClientAsync(new Uri($"http://{host}/onvif/device_service"), username, password);
+            return await CreateDeviceClientAsync(new Uri($"http://{host}/onvif/device_service"), username, password).ConfigureAwait(false);
         }
 
         public static async Task<DeviceClient> CreateDeviceClientAsync(Uri uri, string username, string password)
@@ -43,14 +43,14 @@ namespace Onvif.Core.Client
             var binding = CreateBinding();
             var endpoint = new EndpointAddress(uri);
             var device = new DeviceClient(binding, endpoint);
-            var time_shift = await GetDeviceTimeShift(device);
+            var time_shift = await GetDeviceTimeShift(device).ConfigureAwait(false);
 
             device = new DeviceClient(binding, endpoint);
             device.ChannelFactory.Endpoint.EndpointBehaviors.Clear();
             device.ChannelFactory.Endpoint.EndpointBehaviors.Add(new SoapSecurityHeaderBehavior(username, password, time_shift));
 
             // Connectivity Test
-            await device.OpenAsync();
+            await device.OpenAsync().ConfigureAwait(false);
 
             return device;
         }
@@ -58,16 +58,16 @@ namespace Onvif.Core.Client
         public static async Task<MediaClient> CreateMediaClientAsync(string host, string username, string password)
         {
             var binding = CreateBinding();
-            var device = await CreateDeviceClientAsync(host, username, password);
-            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.Media });
+            var device = await CreateDeviceClientAsync(host, username, password).ConfigureAwait(false);
+            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.Media }).ConfigureAwait(false);
             var media = new MediaClient(binding, new EndpointAddress(new Uri(caps.Capabilities.Media.XAddr)));
 
-            var time_shift = await GetDeviceTimeShift(device);
+            var time_shift = await GetDeviceTimeShift(device).ConfigureAwait(false);
             media.ChannelFactory.Endpoint.EndpointBehaviors.Clear();
             media.ChannelFactory.Endpoint.EndpointBehaviors.Add(new SoapSecurityHeaderBehavior(username, password, time_shift));
 
             // Connectivity Test
-            await media.OpenAsync();
+            await media.OpenAsync().ConfigureAwait(false);
 
             return media;
         }
@@ -75,16 +75,16 @@ namespace Onvif.Core.Client
         public static async Task<PTZClient> CreatePTZClientAsync(string host, string username, string password)
         {
             var binding = CreateBinding();
-            var device = await CreateDeviceClientAsync(host, username, password);
-            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.PTZ });
+            var device = await CreateDeviceClientAsync(host, username, password).ConfigureAwait(false);
+            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.PTZ }).ConfigureAwait(false);
             var ptz = new PTZClient(binding, new EndpointAddress(new Uri(caps.Capabilities.PTZ.XAddr)));
 
-            var time_shift = await GetDeviceTimeShift(device);
+            var time_shift = await GetDeviceTimeShift(device).ConfigureAwait(false);
             ptz.ChannelFactory.Endpoint.EndpointBehaviors.Clear();
             ptz.ChannelFactory.Endpoint.EndpointBehaviors.Add(new SoapSecurityHeaderBehavior(username, password, time_shift));
 
             // Connectivity Test
-            await ptz.OpenAsync();
+            await ptz.OpenAsync().ConfigureAwait(false);
 
             return ptz;
         }
@@ -92,23 +92,23 @@ namespace Onvif.Core.Client
         public static async Task<ImagingClient> CreateImagingClientAsync(string host, string username, string password)
         {
             var binding = CreateBinding();
-            var device = await CreateDeviceClientAsync(host, username, password);
-            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.Imaging });
+            var device = await CreateDeviceClientAsync(host, username, password).ConfigureAwait(false);
+            var caps = await device.GetCapabilitiesAsync(new CapabilityCategory[] { CapabilityCategory.Imaging }).ConfigureAwait(false);
             var imaging = new ImagingClient(binding, new EndpointAddress(new Uri(caps.Capabilities.Imaging.XAddr)));
 
-            var time_shift = await GetDeviceTimeShift(device);
+            var time_shift = await GetDeviceTimeShift(device).ConfigureAwait(false);
             imaging.ChannelFactory.Endpoint.EndpointBehaviors.Clear();
             imaging.ChannelFactory.Endpoint.EndpointBehaviors.Add(new SoapSecurityHeaderBehavior(username, password, time_shift));
 
             // Connectivity Test
-            await imaging.OpenAsync();
+            await imaging.OpenAsync().ConfigureAwait(false);
 
             return imaging;
         }
 
         public static async Task<TimeSpan> GetDeviceTimeShift(this DeviceClient device)
         {
-            var utc = (await device.GetSystemDateAndTimeAsync()).UTCDateTime;
+            var utc = (await device.GetSystemDateAndTimeAsync().ConfigureAwait(false)).UTCDateTime;
             var dt = new System.DateTime(utc.Date.Year, utc.Date.Month, utc.Date.Day,
                               utc.Time.Hour, utc.Time.Minute, utc.Time.Second);
             return dt - System.DateTime.UtcNow;

--- a/Client/Security/SoapSecurityHeader.cs
+++ b/Client/Security/SoapSecurityHeader.cs
@@ -1,80 +1,107 @@
 ﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.ServiceModel.Channels;
 using System.Text;
 using System.Xml;
 
-namespace Onvif.Core.Client.Security {
-	public class SoapSecurityHeader : MessageHeader {
-		const string ns_wsu = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
-		readonly string username;
-		readonly string password;
-		readonly TimeSpan time_shift;
+namespace Onvif.Core.Client.Security
+{
+    public class SoapSecurityHeader : MessageHeader
+    {
+        const string ns_wsu = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+        readonly string username;
+        readonly string password;
+        readonly TimeSpan time_shift;
 
-		public override string Name { get; } = "Security";
-		public override string Namespace { get; } = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+        public override string Name { get; } = "Security";
+        public override string Namespace { get; } = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
 
-		public SoapSecurityHeader (string username, string password, TimeSpan timeShift)
-		{
-			this.username = username;
-			this.password = password;
-			time_shift = timeShift;
-		}
+        public SoapSecurityHeader(string username, string password, TimeSpan timeShift)
+        {
+            this.username = username;
+            this.password = password;
+            time_shift = timeShift;
+        }
 
-		protected override void OnWriteHeaderContents (XmlDictionaryWriter writer, MessageVersion messageVersion)
-		{
-			var nonce = GetNonce ();
-			var created = DateTime.UtcNow.Add (time_shift).ToString ("yyyy-MM-ddTHH:mm:ss.fffZ");
-			var nonce_str = Convert.ToBase64String (nonce);
-			string password_hash = PasswordDigest (nonce, created, password);
+        protected override void OnWriteHeaderContents(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            var nonce = GetNonce();
+            var created = DateTime.UtcNow.Add(time_shift).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            var nonce_str = Convert.ToBase64String(nonce);
+            string password_hash = PasswordDigest(nonce, created, password);
 
-			writer.WriteStartElement ("UsernameToken");
+            writer.WriteStartElement("UsernameToken");
 
-			writer.WriteStartElement ("Username");
-			writer.WriteValue (username);
-			writer.WriteEndElement ();
+            writer.WriteStartElement("Username");
+            writer.WriteValue(username);
+            writer.WriteEndElement();
 
-			writer.WriteStartElement ("Password");
-			writer.WriteAttributeString ("Type", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest");
-			writer.WriteValue (password_hash);
-			writer.WriteEndElement ();
+            writer.WriteStartElement("Password");
+            writer.WriteAttributeString("Type", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest");
+            writer.WriteValue(password_hash);
+            writer.WriteEndElement();
 
-			writer.WriteStartElement ("Nonce");
-			writer.WriteAttributeString ("EncodingType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary");
-			writer.WriteValue (nonce_str);
-			writer.WriteEndElement ();
+            writer.WriteStartElement("Nonce");
+            writer.WriteAttributeString("EncodingType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary");
+            writer.WriteValue(nonce_str);
+            writer.WriteEndElement();
 
-			writer.WriteStartElement ("Created");
-			writer.WriteXmlnsAttribute ("", ns_wsu);
-			writer.WriteValue (created);
-			writer.WriteEndElement ();
+            writer.WriteStartElement("Created");
+            writer.WriteXmlnsAttribute("", ns_wsu);
+            writer.WriteValue(created);
+            writer.WriteEndElement();
 
-			writer.WriteEndElement ();
-		}
+            writer.WriteEndElement();
+        }
 
-		protected override void OnWriteStartHeader (XmlDictionaryWriter writer, MessageVersion messageVersion)
-		{
-			writer.WriteStartElement ("", Name, Namespace);
-			writer.WriteAttributeString ("s", "mustUnderstand", "http://www.w3.org/2003/05/soap-envelope", "1");
-			writer.WriteXmlnsAttribute ("", Namespace);
-		}
+        protected override void OnWriteStartHeader(XmlDictionaryWriter writer, MessageVersion messageVersion)
+        {
+            writer.WriteStartElement("", Name, Namespace);
+            writer.WriteAttributeString("s", "mustUnderstand", "http://www.w3.org/2003/05/soap-envelope", "1");
+            writer.WriteXmlnsAttribute("", Namespace);
+        }
 
-		string PasswordDigest (byte [] nonce, string created, string secret)
-		{
-			byte [] buffer = new byte [nonce.Length + Encoding.ASCII.GetByteCount (created + secret)];
+        string PasswordDigest(byte[] nonce, string created, string secret)
+        {
+            string str = created + secret;
+            int nonceLength = nonce.Length;
+            int strLength = str.Length;
 
-			nonce.CopyTo (buffer, 0);
-			Encoding.ASCII.GetBytes (created + password).CopyTo (buffer, nonce.Length);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent((nonceLength + strLength) << 1);
 
-			return Convert.ToBase64String (SHA1.Create ().ComputeHash (buffer));
-		}
+            unsafe
+            {
+                fixed (byte* noncePtr = nonce,
+                             bufferPtr = buffer)
+                {
+                    Unsafe.CopyBlock(bufferPtr, noncePtr, (uint)nonceLength);
+                }
+            }
 
-		byte [] GetNonce ()
-		{
-			byte [] nonce = new byte [0x10];
-			var generator = new RNGCryptoServiceProvider ();
-			generator.GetBytes (nonce);
-			return nonce;
-		}
-	}
+            try
+            {
+                int strBytesLength = Encoding.ASCII.GetBytes(str, 0, strLength, buffer, nonceLength);
+                using (SHA1 sha1 = SHA1.Create())
+                {
+                    return Convert.ToBase64String(sha1.ComputeHash(buffer, 0, nonceLength + strBytesLength));
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        byte[] GetNonce()
+        {
+            byte[] nonce = new byte[0x10];
+            using (var generator = new RNGCryptoServiceProvider())
+            {
+                generator.GetBytes(nonce);
+                return nonce;
+            }
+        }
+    }
 }

--- a/Discovery/Common/ExtensionMethods.cs
+++ b/Discovery/Common/ExtensionMethods.cs
@@ -13,11 +13,11 @@ namespace Onvif.Core.Discovery.Common
 		{
 			var tcs = new TaskCompletionSource<bool> ();
 			using (cancellationToken.Register (s => ((TaskCompletionSource<bool>)s).TrySetResult (true), tcs)) {
-				if (task != await Task.WhenAny (task, tcs.Task)) {
+				if (task != await Task.WhenAny (task, tcs.Task).ConfigureAwait(false)) {
 					throw new OperationCanceledException (cancellationToken);
 				}
 			}
-			return await task;
+			return await task.ConfigureAwait(false);
 		}
 	}
 }

--- a/Discovery/Common/UdpClientWrapper.cs
+++ b/Discovery/Common/UdpClientWrapper.cs
@@ -29,12 +29,12 @@ namespace Onvif.Core.Discovery.Common
 
 		public async Task<int> SendAsync (byte[] datagram, int bytes, IPEndPoint endPoint)
 		{
-			return await client.SendAsync (datagram, bytes, endPoint);
+			return await client.SendAsync (datagram, bytes, endPoint).ConfigureAwait(false);
 		}
 
 		public async Task<UdpReceiveResult> ReceiveAsync ()
 		{
-			return await client.ReceiveAsync ();
+			return await client.ReceiveAsync ().ConfigureAwait(false);
 		}
 
 		public void Close ()

--- a/Discovery/Common/UdpClientWrapper.cs
+++ b/Discovery/Common/UdpClientWrapper.cs
@@ -10,9 +10,10 @@ namespace Onvif.Core.Discovery.Common
 	/// </summary>
 	public class UdpClientWrapper : IUdpClient
 	{
-		UdpClient client;
+		private readonly UdpClient client;
+		private bool _disposedValue;
 
-		public UdpClientWrapper ()
+        public UdpClientWrapper ()
 		{
 			client = new UdpClient {
 				EnableBroadcast = true
@@ -40,5 +41,23 @@ namespace Onvif.Core.Discovery.Common
 		{
 			client.Close ();
 		}
-	}
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+					client?.Dispose();
+                }
+                _disposedValue = true;
+            }
+        }
+ 
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            System.GC.SuppressFinalize(this);
+        }
+    }
 }

--- a/Discovery/DiscoveryService.cs
+++ b/Discovery/DiscoveryService.cs
@@ -33,7 +33,7 @@ namespace Onvif.Core.Discovery
 			cancellation = new CancellationTokenSource ();
 			try {
 				while (isRunning) {
-					var devicesDiscovered = await wsDiscovery.Discover (Constants.WS_TIMEOUT);
+					var devicesDiscovered = await wsDiscovery.Discover (Constants.WS_TIMEOUT).ConfigureAwait(false);
 					SyncDiscoveryDevices (devicesDiscovered);
 				}
 			} catch (OperationCanceledException) {

--- a/Discovery/Interfaces/IUdpClient.cs
+++ b/Discovery/Interfaces/IUdpClient.cs
@@ -1,16 +1,17 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Onvif.Core.Discovery.Interfaces
 {
-	/// <summary>
-	/// UDP Client interface to wrapp UdpClient and easily mock <see cref="System.Net.Sockets.UdpClient"/> in tests
-	/// </summary>
-	public interface IUdpClient
-	{
-		Task<int> SendAsync (byte[] datagram, int bytes, IPEndPoint endPoint);
-		Task<UdpReceiveResult> ReceiveAsync ();
-		void Close ();
-	}
+    /// <summary>
+    /// UDP Client interface to wrapp UdpClient and easily mock <see cref="System.Net.Sockets.UdpClient"/> in tests
+    /// </summary>
+    public interface IUdpClient : IDisposable
+    {
+        Task<int> SendAsync(byte[] datagram, int bytes, IPEndPoint endPoint);
+        Task<UdpReceiveResult> ReceiveAsync();
+        void Close();
+    }
 }

--- a/Discovery/Models/DiscoveryDevice.cs
+++ b/Discovery/Models/DiscoveryDevice.cs
@@ -1,55 +1,113 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 
 namespace Onvif.Core.Discovery.Models
 {
-	public class DiscoveryDevice
-	{
-		public IEnumerable<string> Types { get; internal set; }
-		public IEnumerable<string> XAdresses { get; internal set; }
-		public string Model { get; internal set; }
-		public string Name { get; internal set; }
-		public IPAddress Address { get; internal set; }
+    public class DiscoveryDevice : IEquatable<DiscoveryDevice>
+    {
+        public IEnumerable<string> Types { get; internal set; }
+        public IEnumerable<string> XAdresses { get; internal set; }
+        public string Model { get; internal set; }
+        public string Name { get; internal set; }
+        public IPAddress Address { get; internal set; }
 
-		public override bool Equals (object obj)
-		{
-			var o = obj as DiscoveryDevice;
-			if (o == null) {
-				return false;
-			}
-			if (o.Model != Model || o.Name != Name || o.Address != Address
-				|| o.Types.Count() != Types.Count() || o.XAdresses.Count() != XAdresses.Count()) {
-				return false;
-			}
-			for (var i = 0; i < Types.Count(); i++) {
-				if (!Types.ElementAt(i).Equals (o.Types.ElementAt(i))) {
-					return false;
-				}
-			}
-			for (var i = 0; i < XAdresses.Count (); i++) {
-				if (!XAdresses.ElementAt (i).Equals (o.XAdresses.ElementAt (i))) {
-					return false;
-				}
-			}
-			return true;
-		}
+        public override bool Equals(object obj)
+        {
+            return obj is DiscoveryDevice o &&
+                    Equals(o);
+        }
 
-		public override int GetHashCode ()
-		{
-			var hash = 1;
-			if (Types != null) {
-				foreach (var type in Types) {
-					hash += type.GetHashCode ();
-				}
-			}
-			if (XAdresses != null) {
-				foreach (var address in XAdresses) {
-					hash += address.GetHashCode ();
-				}
-			}
-			hash += (Model?.GetHashCode () + Name?.GetHashCode () + Address?.GetHashCode ()) ?? 0;
-			return hash;
-		}
-	}
+        public bool Equals(DiscoveryDevice other)
+        {
+            if (other == null ||
+                Model != other.Model ||
+                Name != other.Name)
+            {
+                return false;
+            }
+
+            if (Address == null)
+            {
+                if (other.Address != null)
+                {
+                    return false;
+                }
+            }
+            else if (!Address.Equals(other.Address))
+            {
+                return false;
+            }
+
+            return SequenceEqualCore(Types, other.Types) &&
+                   SequenceEqualCore(XAdresses, other.XAdresses);
+        }
+
+        public override int GetHashCode()
+        {
+            const int FnvOffsetBias = unchecked((int)2166136261);
+
+            int hash = FnvOffsetBias;
+
+            CombineListHash(ref hash, Types);
+            CombineListHash(ref hash, XAdresses);
+
+            if (Model != null)
+            {
+                CombineHashCode(ref hash, Model.GetHashCode());
+            }
+
+            if (Name != null)
+            {
+                CombineHashCode(ref hash, Name.GetHashCode());
+            }
+
+            if (Address != null)
+            {
+                CombineHashCode(ref hash, Address.GetHashCode());
+            }
+
+            return hash;
+        }
+
+        private static bool SequenceEqualCore(IEnumerable<string> self, IEnumerable<string> other)
+        {
+            if (self == null)
+            {
+                return other == null;
+            }
+            else if (other == null)
+            {
+                return false;
+            }
+            return self.SequenceEqual(other);
+        }
+
+        private static void CombineListHash(ref int hash, IEnumerable<string> list)
+        {
+            if (list != null)
+            {
+                foreach (string item in list)
+                {
+                    CombineHashCode(ref hash, item.GetHashCode());
+                }
+            }
+        }
+
+        private static void CombineHashCode(ref int hash, int hashcode)
+        {
+            const int FnvPrime = 16777619;
+
+            unsafe
+            {
+                byte* tempPtr = (byte*)&hashcode;
+                hash = unchecked((hash ^ tempPtr[0]) * FnvPrime);
+                hash = unchecked((hash ^ tempPtr[1]) * FnvPrime);
+                hash = unchecked((hash ^ tempPtr[2]) * FnvPrime);
+                hash = unchecked((hash ^ tempPtr[3]) * FnvPrime);
+            }
+        }
+
+    }
 }

--- a/Discovery/WSDiscovery.cs
+++ b/Discovery/WSDiscovery.cs
@@ -33,7 +33,7 @@ namespace Onvif.Core.Discovery
             var isRunning = false;
             var responses = new List<UdpReceiveResult>();
 
-            await SendProbe(client);
+            await SendProbe(client).ConfigureAwait(false);
             try
             {
                 isRunning = true;
@@ -44,7 +44,7 @@ namespace Onvif.Core.Discovery
                     {
                         break;
                     }
-                    var response = await client.ReceiveAsync().WithCancellation(cts.Token).WithCancellation(cancellationToken);
+                    var response = await client.ReceiveAsync().WithCancellation(cts.Token).WithCancellation(cancellationToken).ConfigureAwait(false);
                     responses.Add(response);
                 }
             }
@@ -69,7 +69,7 @@ namespace Onvif.Core.Discovery
         {
             var message = WSProbeMessageBuilder.NewProbeMessage();
             var multicastEndpoint = new IPEndPoint(IPAddress.Parse(Constants.WS_MULTICAST_ADDRESS), Constants.WS_MULTICAST_PORT);
-            await client.SendAsync(message, message.Length, multicastEndpoint);
+            await client.SendAsync(message, message.Length, multicastEndpoint).ConfigureAwait(false);
         }
 
         IEnumerable<DiscoveryDevice> ProcessResponses(IEnumerable<UdpReceiveResult> responses)

--- a/Discovery/WSDiscovery.cs
+++ b/Discovery/WSDiscovery.cs
@@ -17,6 +17,9 @@ namespace Onvif.Core.Discovery
 {
     public class WSDiscovery : IWSDiscovery
     {
+        private static readonly Regex _regexModel = new Regex("(?<=hardware/).*?(?= )", RegexOptions.Compiled);
+        private static readonly Regex _regexName = new Regex("(?<=name/).*?(?= )", RegexOptions.Compiled);
+
         public Task<IEnumerable<DiscoveryDevice>> Discover(int timeout,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -123,12 +126,12 @@ namespace Onvif.Core.Discovery
 
         string ParseModelFromScopes(string scopes)
         {
-            return Regex.Match(scopes, "(?<=hardware/).*?(?= )").Value;
+            return _regexModel.Match(scopes).Value;
         }
 
         string ParseNameFromScopes(string scopes)
         {
-            return Regex.Match(scopes, "(?<=name/).*?(?= )").Value;
+            return _regexName.Match(scopes).Value;
         }
     }
 }

--- a/Discovery/WSDiscovery.cs
+++ b/Discovery/WSDiscovery.cs
@@ -52,6 +52,7 @@ namespace Onvif.Core.Discovery
             finally
             {
                 client.Close();
+                client.Dispose();
             }
             if (cancellationToken.IsCancellationRequested)
             {

--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -13,6 +13,7 @@
     <AssemblyVersion>2.2.2.0</AssemblyVersion>
     <PackageProjectUrl>https://github.com/Jazea/Onvif.Core</PackageProjectUrl>
     <PackageTags>onvif camera ptz</PackageTags>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -17,6 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.9.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.9.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.9.0" />

--- a/Onvif.Core.sln
+++ b/Onvif.Core.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Onvif.Core", "Onvif.Core.csproj", "{3235B0D4-50F8-4B2D-A71C-437ACD7D83C4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3235B0D4-50F8-4B2D-A71C-437ACD7D83C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3235B0D4-50F8-4B2D-A71C-437ACD7D83C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3235B0D4-50F8-4B2D-A71C-437ACD7D83C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3235B0D4-50F8-4B2D-A71C-437ACD7D83C4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4C9A367E-45E0-4B02-BA8E-0839A356DC0B}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- [add IDisposable interface to IUdpClient](https://github.com/Jazea/Onvif.Core/commit/e3a0f919ba37c256615c1570cd824952c23287de)
Udp客户端必定需要socket资源，这意味着它的正确实施必定要实现IDisposable接口。增加此接口可以保证按期望释放非托管资源。
- [allow unsafe code](https://github.com/Jazea/Onvif.Core/commit/60d0a2e27d0c819130ba39b01b581aaf5b1abe1d)
  增加unsafe惠而不费。
- [fix equals method; change hash algorithm to fnv-1](https://github.com/Jazea/Onvif.Core/commit/0b17e030e8a246cc33272be4800aaad50f836d0c)
  注1: 即便Object重写了Equals方法，`==` 运算符仍然会对比实例是否是同一引用。所以对比Address时要显式使用Equals方法。同时，原有实现浪费了性能，这里采取更好的方式实现。
 注2: GetHashcode可以用FNV-1算法计算。性能高，且离散性好。  
- [precompile regex](https://github.com/Jazea/Onvif.Core/commit/3d7de718e87aef45cf665143dd56a85d5bc100fd)
  预编译正则表达式。
- [add ConfigureAwait(false) to improve performance](https://github.com/Jazea/Onvif.Core/commit/bb490cfac96c7f439b296c8d9a81880359ec5172)
  [详见](https://devblogs.microsoft.com/dotnet/configureawait-faq/)
- [add library](https://github.com/Jazea/Onvif.Core/commit/ecb61c2471138e9dbc3c5fe6d77a063890d30451)
  引用的库都是现有库依赖的，直接传递，没有引入额外的库。
- [improve performance of PasswordDigest method](https://github.com/Jazea/Onvif.Core/commit/ca2f88c8e613a026edac477d4c8686852934ad83)
  优化点1：缓冲区池
  优化点2:  Unsafe拷贝数组
  优化点3:  Encoding.ASCII.GetBytes直接写入缓冲区
  其他：正确释放实现了IDisposable接口的对象。