### PR TITLE
Update packages

### DIFF
--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Jazea.org</Authors>
@@ -22,18 +22,18 @@
   <ItemGroup>
     <None Include="res\icon.png" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath=""/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.1" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.6.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.3" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.3" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.10.3" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.1" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.1" />
+    <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`System.ServiceModel.Http` version 4.10.3 collides with newer versions that are implicitly included in dotnet8 projects, and causes runtime errors. This also updates other out-of-date packages. 

```
Message: Attempted to access an element as a type incompatible with the array.
Source: System.Private.CoreLib
StackTrace:
   at System.Collections.Generic.List`1.Insert(Int32 index, T item)
   at System.ServiceModel.Channels.BindingElementCollection.InsertItem(Int32 index, BindingElement item)
   at Onvif.Core.Client.OnvifClientFactory.CreateBinding() in /home/joe/Onvif.Core/Client/OnvifClientFactory.cs:line 32
   at Onvif.Core.Client.OnvifClientFactory.CreateDeviceClientAsync(Uri uri, String username, String password) in /home/joe/Onvif.Core/Client/OnvifClientFactory.cs:line 44
   at Onvif.Core.Client.OnvifClientFactory.CreateDeviceClientAsync(String host, String username, String password) in /home/joe/Onvif.Core/Client/OnvifClientFactory.cs:line 39
   at Onvif.Test.Program.Main(String[] args) in /home/joe/Onvif.Test/Program.cs:line 14
```