### PR TITLE
Add configurable WCF binding timeouts for ONVIF clients

### DIFF
--- a/Client/OnvifBindingTimeoutConfiguration.cs
+++ b/Client/OnvifBindingTimeoutConfiguration.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Onvif.Core.Client;
+
+/// <summary>
+/// Configuration settings for WCF binding timeouts used in ONVIF client creation.
+/// Null values indicate that WCF defaults should be used (no override).
+/// Set a value to override the corresponding WCF binding timeout.
+/// </summary>
+public sealed class OnvifBindingTimeoutConfiguration
+{
+	/// <summary>
+	/// Gets or sets the timeout for opening a connection to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? OpenTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for sending data to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? SendTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for receiving data from the ONVIF service.
+	/// When null, uses WCF default (10 minutes).
+	/// </summary>
+	public TimeSpan? ReceiveTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for closing a connection to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? CloseTimeout { get; set; }
+}

--- a/Client/OnvifClientFactory.cs
+++ b/Client/OnvifClientFactory.cs
@@ -14,6 +14,15 @@ namespace Onvif.Core.Client;
 
 public static class OnvifClientFactory
 {
+	/// <summary>
+	/// Global configuration for WCF binding timeouts applied to all ONVIF clients created by this factory.
+	/// Can be modified before creating any clients to customize timeout behavior globally.
+	/// 
+	/// When configured, these timeouts override the WCF defaults.
+	/// When null (default), WCF defaults are used (preserves original library behavior).
+	/// </summary>
+	public static OnvifBindingTimeoutConfiguration? BindingTimeoutConfig { get; set; }
+
 	static Binding CreateBinding()
 	{
 		var binding = new CustomBinding();
@@ -30,6 +39,19 @@ public static class OnvifClientFactory
 
 		binding.Elements.Add(textBindingElement);
 		binding.Elements.Add(httpBindingElement);
+
+		// Apply timeout configuration only for values that are explicitly set (non-null)
+		if (BindingTimeoutConfig is not null)
+		{
+			if (BindingTimeoutConfig.OpenTimeout is not null)
+				binding.OpenTimeout = BindingTimeoutConfig.OpenTimeout.Value;
+			if (BindingTimeoutConfig.SendTimeout is not null)
+				binding.SendTimeout = BindingTimeoutConfig.SendTimeout.Value;
+			if (BindingTimeoutConfig.ReceiveTimeout is not null)
+				binding.ReceiveTimeout = BindingTimeoutConfig.ReceiveTimeout.Value;
+			if (BindingTimeoutConfig.CloseTimeout is not null)
+				binding.CloseTimeout = BindingTimeoutConfig.CloseTimeout.Value;
+		}
 
 		return binding;
 	}

--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -18,6 +18,7 @@
     <LangVersion>12.0</LangVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION

## Description

### Purpose
Add support for configurable WCF binding timeouts in the ONVIF client factory to enable faster failure detection and better control over network operation timeouts.

### Problem
WCF bindings use 1-minute default timeouts for connection operations, which can cause long delays when cameras are unreachable or unresponsive. Applications need the ability to override these timeouts for faster failure handling.

### Solution
Introduced `OnvifBindingTimeoutConfiguration` class with four nullable timeout properties:
- `OpenTimeout` - Connection establishment timeout
- `SendTimeout` - Request transmission timeout  
- `ReceiveTimeout` - Response reception timeout
- `CloseTimeout` - Connection closure timeout

Configuration is opt-in via `OnvifClientFactory.BindingTimeoutConfig` static property. Null values preserve WCF defaults, ensuring backward compatibility.

### Changes
- Added `OnvifBindingTimeoutConfiguration.cs` - New configuration class with nullable timeout properties
- Modified `OnvifClientFactory.cs` - Added `BindingTimeoutConfig` static property and timeout application logic
- Timeouts only applied when explicitly configured; unset values use WCF defaults

### Backward Compatibility
✅ Fully backward compatible - library behavior unchanged unless `BindingTimeoutConfig` is explicitly set

### Usage Example

Override all default WCF timeouts:
```csharp
// Override default WCF timeouts
OnvifClientFactory.BindingTimeoutConfig = new OnvifBindingTimeoutConfiguration
{
    OpenTimeout = TimeSpan.FromSeconds(8),
    SendTimeout = TimeSpan.FromSeconds(8),
    ReceiveTimeout = TimeSpan.FromSeconds(8),
    CloseTimeout = TimeSpan.FromSeconds(8)
};

// Clients created after this will use the configured timeouts
var device = await OnvifClientFactory.CreateDeviceClientAsync(host, username, password);

// Or set individual timeouts:
OnvifClientFactory.BindingTimeoutConfig = new OnvifBindingTimeoutConfiguration
{
    OpenTimeout = TimeSpan.FromSeconds(8)  // Only override OpenTimeout
    // SendTimeout, ReceiveTimeout, CloseTimeout remain at WCF defaults
};