### PR TITLE
feat: Add configurable WCF binding timeouts for ONVIF clients

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,228 @@
+# Onvif.Core - AI Coding Instructions
+
+## Project Overview
+Onvif.Core is a **stable, production-grade** .NET Standard library for ONVIF camera discovery and control. It provides both network discovery of IP cameras and full client functionality for PTZ (Pan-Tilt-Zoom), media, imaging, and device management via SOAP web services.
+
+### Stability & API Compatibility
+**This is a stable library.** Backward compatibility and API stability are paramount:
+- **Never break existing APIs** - no public method/property removals, renamings, or signature changes
+- **Only extend, never contract** - add new methods/overloads, do not modify existing ones
+- **Make minimal changes** - apply only the smallest necessary changes to fix bugs or add features
+- **Deprecate cautiously** - use `[Obsolete]` attributes with clear migration paths when API changes are unavoidable
+- **Document all changes** - explain the purpose and impact of every modification in code comments and commit messages
+
+## Architecture & Key Components
+
+### Core Architecture Pattern
+- **Factory-based client creation**: Use `OnvifClientFactory` for all SOAP clients (Device, PTZ, Media, Imaging)
+- **Singleton camera management**: `Camera.Create()` maintains a static dictionary of cameras keyed by `Account`
+- **Lazy client initialization**: Camera properties (`Ptz`, `Media`, `Imaging`) create clients on first access
+- **SOAP security**: All clients use WS-Security with digest authentication via `SoapSecurityHeader`
+
+### Main Components
+1. **Discovery** (`Discovery/`): UDP multicast WS-Discovery for finding cameras on network
+2. **Client** (`Client/`): SOAP client wrappers for ONVIF services
+3. **Security** (`Client/Security/`): WS-Security implementation with time-shifted nonce generation
+4. **Data Types**: Auto-generated from WSDL files in `wsdl/` directory
+
+### Key Classes & Usage Patterns
+
+#### Camera Creation & Management
+```csharp
+// Always use factory method - never 'new Camera()'
+var account = new Account("192.168.1.100", "admin", "password");
+var camera = await Camera.CreateAsync(account, ex => Console.WriteLine(ex));
+```
+
+#### Client Access Pattern
+```csharp
+// Clients are lazy-loaded properties, not constructor injected
+await camera.Ptz.AbsoluteMoveAsync(profileToken, position, speed);
+await camera.Media.GetProfilesAsync();
+```
+
+## Development Guidelines
+
+### API Stability & Backward Compatibility (Critical)
+Before making ANY changes to public APIs:
+1. **Check for existing usage** - search the entire codebase for references to the API being modified
+2. **Preserve signatures** - existing method/property signatures must remain unchanged
+3. **Only add, never remove** - new overloads and members are acceptable; removals/renames are not
+4. **Use [Obsolete] for migrations** - if a public method must change, mark the old one as `[Obsolete("Use NewMethod instead.", error: false)]`
+5. **Document breaking change** - add XML comments explaining the migration path and why the change was necessary
+6. **Version bump** - breaking changes require major version increments (follows semver)
+
+**Example of acceptable change:**
+```csharp
+// OLD: Keep existing method
+public async Task<Profile> GetProfileAsync(string profileToken)
+{
+    return await GetProfileAsync(profileToken, CancellationToken.None);
+}
+
+// NEW: Add new overload, don't modify existing
+public async Task<Profile> GetProfileAsync(string profileToken, CancellationToken cancellationToken)
+{
+    // Implementation
+}
+```
+
+**Example of unacceptable change:**
+```csharp
+// WRONG: Don't remove or change existing method signature
+// public async Task<Profile> GetProfileAsync(string profileToken) // REMOVED - breaks consumers!
+```
+
+### SOAP Client Development
+- WSDL files in `wsdl/` are source of truth for service contracts
+- All clients inherit from generated ServiceModel proxies
+- Custom binding always uses SOAP 1.2 with HTTP transport (`OnvifClientFactory.CreateBinding()`)
+- Time synchronization is critical - get device time first via `GetDeviceTimeShift()`
+
+### Security Implementation
+- Username token with digest authentication is required for all ONVIF calls
+- Nonce generation uses cryptographically secure random bytes
+- Created timestamp must account for camera/server time difference
+- Security headers are injected via `SoapSecurityHeaderBehavior`
+
+### Discovery Service
+- Uses UDP multicast to 239.255.255.250:3702
+- Sends WS-Discovery Probe messages
+- Parses device responses for service URLs and scopes
+- Can bind to specific network interfaces via `UdpClientWrapper`
+
+### Error Handling Patterns
+- Camera creation includes exception callback: `Camera.Create(account, ex => { })`
+- Client calls should wrap in try-catch as SOAP faults are common
+- Network timeouts and unreachable devices are expected scenarios
+
+## Build & Development
+
+### Project Structure
+- **Target Frameworks**: .NET Standard 2.0 and 2.1
+- **Dependencies**: System.ServiceModel.* packages for SOAP, security packages for WS-Security
+- **Output**: NuGet package with embedded WSDL files and README
+
+### Key Commands
+```powershell
+# Build package
+dotnet pack
+
+# Build specific framework
+dotnet build -f netstandard2.1
+
+# Test with specific camera (no unit tests - requires hardware)
+# Use examples in README.md for manual testing
+```
+
+### Performance Considerations
+- Camera instances are cached by Account to avoid repeated authentication
+- Clients use object pooling for UDP sockets in discovery
+- Custom FNV-1a hash implementation for efficient Account equality
+- SOAP clients should be reused, not recreated per call
+
+## Common Patterns & Conventions
+
+### Async/Await Usage
+- All public APIs are async with `ConfigureAwait(false)`
+- Synchronous wrappers use `.Result` (Camera.Create vs CreateAsync)
+- CancellationToken support in discovery operations
+
+### ONVIF-Specific Patterns
+- Profile tokens identify camera configurations
+- PTZ operations require both position AND speed vectors
+- Media profiles contain stream URIs and codec information
+- Device time synchronization prevents authentication failures
+
+### Code Generation
+- DataTypes classes are generated from XSD schemas
+- Use `[XmlType]` attributes with proper ONVIF namespaces
+- Maintain compatibility with ONVIF specification versions (v10, v20)
+
+## Nullable Reference Types
+
+### Project Configuration
+- **Note**: The Onvif.Core project does **not** have `<Nullable>enable</Nullable>` globally enabled to preserve backward compatibility with existing and WCF-generated code.
+- Nullable reference type checking is **opt-in only** for new code that requires null-safety.
+
+### Using Nullable Reference Types for New Code
+When creating **new classes** that require null-safety, enable nullable reference types using the `#nullable enable` pragma at the top of the file:
+
+```csharp
+#nullable enable
+
+using System;
+
+namespace Onvif.Core.Client;
+
+/// <summary>
+/// Configuration for WCF binding timeouts.
+/// Null values indicate that WCF defaults should be used (no override).
+/// </summary>
+public sealed class OnvifBindingTimeoutConfiguration
+{
+    public TimeSpan? OpenTimeout { get; set; }  // Nullable value type: null = use WCF default
+    public TimeSpan? SendTimeout { get; set; }
+    public TimeSpan? ReceiveTimeout { get; set; }
+    public TimeSpan? CloseTimeout { get; set; }
+}
+```
+
+### Guidelines for Nullable Reference Types
+1. **Use `#nullable enable` only for new, safety-critical code** - Do not add it retroactively to existing code
+2. **Do not modify generated code** - WCF-generated DataTypes.cs and WSDL-derived classes should remain untouched
+3. **Distinguish between nullable types**:
+   - `TimeSpan?` = nullable **value type** (means "value or nothing")
+   - `string?` = nullable **reference type** (means "reference or null")
+   - Use explicit nullable annotations to document API contracts
+4. **Document null semantics** - Always explain in XML comments what null means for your property/parameter
+5. **Preserve stability** - New nullable code must not break existing consumers
+
+## Code Documentation & Comments
+
+### XML Documentation Requirements
+All public APIs must have complete XML documentation (`///` comments):
+
+```csharp
+/// <summary>
+/// Creates a new camera instance for the specified account.
+/// </summary>
+/// <param name="account">The camera account with connection credentials.</param>
+/// <param name="exceptionHandler">Callback invoked when connection errors occur (optional).</param>
+/// <returns>A new Camera instance, or null if creation failed.</returns>
+/// <remarks>
+/// Camera instances are cached by Account to prevent duplicate authentication.
+/// The same account will return the existing cached instance.
+/// </remarks>
+public static async Task<Camera> CreateAsync(Account account, Action<Exception> exceptionHandler)
+{
+    // Implementation
+}
+```
+
+### Implementation Comments
+For complex logic, especially in security, discovery, and SOAP binding code:
+- Explain the **why**, not just the **what**
+- Reference ONVIF specifications when relevant
+- Note any deviations from standard patterns with justification
+
+```csharp
+// Time shift is required because ONVIF cameras may have different system clocks than the client.
+// We query device time first, then adjust all nonce timestamps to prevent authentication failures.
+var timeShift = await GetDeviceTimeShift();
+```
+
+### Change Documentation
+When modifying existing code:
+- Add a comment explaining **why** the change was made
+- Reference related issues or requirements if applicable
+- Note any API additions clearly
+
+```csharp
+// CHANGE: Added CancellationToken support to allow graceful shutdown during discovery
+// This prevents orphaned socket connections when the application terminates.
+public async Task<IEnumerable<OnvifCamera>> DiscoverAsync(CancellationToken cancellationToken)
+{
+    // Implementation
+}
+```

--- a/Client/OnvifBindingTimeoutConfiguration.cs
+++ b/Client/OnvifBindingTimeoutConfiguration.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Onvif.Core.Client;

--- a/Client/OnvifBindingTimeoutConfiguration.cs
+++ b/Client/OnvifBindingTimeoutConfiguration.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Onvif.Core.Client;
+
+/// <summary>
+/// Configuration settings for WCF binding timeouts used in ONVIF client creation.
+/// Null values indicate that WCF defaults should be used (no override).
+/// Set a value to override the corresponding WCF binding timeout.
+/// </summary>
+public sealed class OnvifBindingTimeoutConfiguration
+{
+	/// <summary>
+	/// Gets or sets the timeout for opening a connection to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? OpenTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for sending data to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? SendTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for receiving data from the ONVIF service.
+	/// When null, uses WCF default (10 minutes).
+	/// </summary>
+	public TimeSpan? ReceiveTimeout { get; set; }
+
+	/// <summary>
+	/// Gets or sets the timeout for closing a connection to the ONVIF service.
+	/// When null, uses WCF default (1 minute).
+	/// </summary>
+	public TimeSpan? CloseTimeout { get; set; }
+}

--- a/Client/OnvifClientFactory.cs
+++ b/Client/OnvifClientFactory.cs
@@ -1,4 +1,6 @@
-﻿using Onvif.Core.Client.Common;
+﻿#nullable enable
+
+using Onvif.Core.Client.Common;
 using Onvif.Core.Client.Device;
 using Onvif.Core.Client.Imaging;
 using Onvif.Core.Client.Media;

--- a/Client/OnvifClientFactory.cs
+++ b/Client/OnvifClientFactory.cs
@@ -14,6 +14,15 @@ namespace Onvif.Core.Client;
 
 public static class OnvifClientFactory
 {
+	/// <summary>
+	/// Global configuration for WCF binding timeouts applied to all ONVIF clients created by this factory.
+	/// Can be modified before creating any clients to customize timeout behavior globally.
+	/// 
+	/// When configured, these timeouts override the WCF defaults.
+	/// When null (default), WCF defaults are used (preserves original library behavior).
+	/// </summary>
+	public static OnvifBindingTimeoutConfiguration? BindingTimeoutConfig { get; set; }
+
 	static Binding CreateBinding()
 	{
 		var binding = new CustomBinding();
@@ -30,6 +39,19 @@ public static class OnvifClientFactory
 
 		binding.Elements.Add(textBindingElement);
 		binding.Elements.Add(httpBindingElement);
+
+		// Apply timeout configuration only for values that are explicitly set (non-null)
+		if (BindingTimeoutConfig is not null)
+		{
+			if (BindingTimeoutConfig.OpenTimeout is not null)
+				binding.OpenTimeout = BindingTimeoutConfig.OpenTimeout.Value;
+			if (BindingTimeoutConfig.SendTimeout is not null)
+				binding.SendTimeout = BindingTimeoutConfig.SendTimeout.Value;
+			if (BindingTimeoutConfig.ReceiveTimeout is not null)
+				binding.ReceiveTimeout = BindingTimeoutConfig.ReceiveTimeout.Value;
+			if (BindingTimeoutConfig.CloseTimeout is not null)
+				binding.CloseTimeout = BindingTimeoutConfig.CloseTimeout.Value;
+		}
 
 		return binding;
 	}

--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -18,7 +18,6 @@
     <LangVersion>12.0</LangVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Onvif.Core.csproj
+++ b/Onvif.Core.csproj
@@ -18,6 +18,7 @@
     <LangVersion>12.0</LangVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

### Purpose
Add support for configurable WCF binding timeouts in the ONVIF client factory to enable faster failure detection and better control over network operation timeouts.

### Problem
WCF bindings use 1-minute default timeouts for connection operations, which can cause long delays when cameras are unreachable or unresponsive. Applications need the ability to override these timeouts for faster failure handling.

### Solution
Introduced `OnvifBindingTimeoutConfiguration` class with four nullable timeout properties:
- `OpenTimeout` - Connection establishment timeout
- `SendTimeout` - Request transmission timeout  
- `ReceiveTimeout` - Response reception timeout
- `CloseTimeout` - Connection closure timeout

Configuration is opt-in via `OnvifClientFactory.BindingTimeoutConfig` static property. Null values preserve WCF defaults, ensuring backward compatibility.

### Changes
- Added `OnvifBindingTimeoutConfiguration.cs` - New configuration class with nullable timeout properties
- Modified `OnvifClientFactory.cs` - Added `BindingTimeoutConfig` static property and timeout application logic
- Timeouts only applied when explicitly configured; unset values use WCF defaults

### Backward Compatibility
✅ Fully backward compatible - library behavior unchanged unless `BindingTimeoutConfig` is explicitly set

### Usage Example

Override all default WCF timeouts:
```csharp
// Override default WCF timeouts
OnvifClientFactory.BindingTimeoutConfig = new OnvifBindingTimeoutConfiguration
{
    OpenTimeout = TimeSpan.FromSeconds(8),
    SendTimeout = TimeSpan.FromSeconds(8),
    ReceiveTimeout = TimeSpan.FromSeconds(8),
    CloseTimeout = TimeSpan.FromSeconds(8)
};

// Clients created after this will use the configured timeouts
var device = await OnvifClientFactory.CreateDeviceClientAsync(host, username, password);

// Or set individual timeouts:
OnvifClientFactory.BindingTimeoutConfig = new OnvifBindingTimeoutConfiguration
{
    OpenTimeout = TimeSpan.FromSeconds(8)  // Only override OpenTimeout
    // SendTimeout, ReceiveTimeout, CloseTimeout remain at WCF defaults
};
```

Enabled `#nullable` for specific class files only, as enabling it in the .csproj would generate over 1,000 warnings due to generated code requiring significant refactoring to support nullable annotations.